### PR TITLE
read .tsv and catch an unsupported file type in dryad_getfile

### DIFF
--- a/R/dryad_getfile.r
+++ b/R/dryad_getfile.r
@@ -1,5 +1,5 @@
 #' Download Dryad dataset (determines file type, then downloads).
-#' 
+#'
 #' @import RCurl XML stringr gdata ape httr
 #' @param dryadurl Dryad URL for a dataset.
 #' @return A Dryad dataset.
@@ -9,7 +9,7 @@
 #' dryaddat <- download_url('10255/dryad.1759')
 #' dryad_getfile(dryaddat)
 #' }
-dryad_getfile <- function(dryadurl) 
+dryad_getfile <- function(dryadurl)
 {
     # Separate out path from rest of URL
     dryadpath <- parse_url(dryadurl)$path
@@ -24,19 +24,25 @@ dryad_getfile <- function(dryadurl)
         "csv"
     } else if (grepl('\\.nex$', dryadpath, ignore.case=TRUE)) {
         "nex"
-    } 
+    } else if (grepl('\\.tsv$', dryadpath, ignore.case=TRUE)) {
+      "tsv"
+    } else {
+      stop("file type not supported!")
+    }
     if (file_type == "txt") {
         dat <- read.table(dryadurl, header = T, sep = "\t")
     } else if (file_type == "xls") {
         dat <- read.xls(dryadurl)  # requires gdata
-    } else if (file_type == "csv" & str_detect(scan(dryadurl, what = "raw")[1], 
+    } else if (file_type == "csv" & str_detect(scan(dryadurl, what = "raw")[1],
         ";") == "TRUE") {
         dat <- read.csv(dryadurl, sep = ";")
-    } else if (file_type == "csv" & str_detect(scan(dryadurl, what = "raw")[1], 
+    } else if (file_type == "csv" & str_detect(scan(dryadurl, what = "raw")[1],
         ";") == "FALSE") {
         dat <- read.csv(dryadurl)
     } else if (file_type == "nex") {
         dat <- read.nexus(dryadurl)  # requires ape
+    } else if (file_type == "tsv") {
+        dat <- read.csv(dryadurl, sep = "\t")
     }
     end
     return(dat)


### PR DESCRIPTION
Some data is in .tsv ([random example](http://datadryad.org/resource/doi:10.5061/dryad.8k55h)), so I added .tsv to the supported file types. I also added a slightly more informative error. 