### PR TITLE
change dryad url to v1.datadryad.org

### DIFF
--- a/R/dryad_solr.r
+++ b/R/dryad_solr.r
@@ -117,7 +117,7 @@ d_solr_stats <- function(..., proxy = NULL, callopts = list()) {
 
 # helpers ---------------------------------------
 make_dryad_conn <- function(proxy) {
-  solrium::SolrClient$new(host = "datadryad.org",
+  solrium::SolrClient$new(host = "v1.datadryad.org",
     path = "solr/search/select", scheme = "https",
     port = NULL, errors = "complete", 
     proxy = proxy)


### PR DESCRIPTION

## Description
changed solr api url to the url where the old system now lives, v1.datadryad.org



